### PR TITLE
Backup support

### DIFF
--- a/.banzaicloud/README.md
+++ b/.banzaicloud/README.md
@@ -13,6 +13,7 @@ helm upgrade --install mysql-operator presslabs/mysql-operator \
   --set orchestrator.antiAffinity=soft \
   --set rbac.create=true \
   --set rbac.serviceAccountName=mysql-operator \
+  --set helperImage="banzaicloud/mysql-helper:0.1.15" \
   --wait
 
 helm upgrade --install mysql-spotguide charts/mysql-spotguide \

--- a/.banzaicloud/charts/mysql-spotguide/templates/mysql-cluster.yaml
+++ b/.banzaicloud/charts/mysql-spotguide/templates/mysql-cluster.yaml
@@ -11,12 +11,18 @@ spec:
   replicas: {{ .Values.mysql.replicas }}
   secretName: {{ default (printf "%s-cluster" (include "mysql-spotguide.fullname" .)) .Values.mysql.existingSecret }}
   mysqlVersion: {{ .Values.mysql.version | quote }}
-  {{- if .Values.mysql.backup.enabled }}
+{{- if .Values.mysql.backup.enabled }}
   backupSchedule: {{ .Values.mysql.backup.schedule }}
+  {{- if eq .Values.mysql.backup.cloud "amazon" }}
   backupUri: "s3://{{ .Values.mysql.backup.bucket }}"
+  {{- else if eq .Values.mysql.backup.cloud "google" }}
+  backupUri: "gs://{{ .Values.mysql.backup.bucket }}"
+  {{- else if eq .Values.mysql.backup.cloud "azure" }}
+  backupUri: "azure://{{ .Values.mysql.backup.bucket }}"
+  {{- end }}
   backupSecretName: {{ .Values.mysql.backup.secret }}
   backupScheduleJobsHistoryLimit: {{ .Values.mysql.backup.limit }}
-  {{- end }}
+{{- end }}
   podSpec:
     securityContext:
       enabled: true

--- a/.banzaicloud/charts/mysql-spotguide/templates/mysql-service.yaml
+++ b/.banzaicloud/charts/mysql-spotguide/templates/mysql-service.yaml
@@ -18,5 +18,5 @@ spec:
   selector:
     app: mysql-operator
     role: master
-    mysql_cluster: {{ include "mysql-spotguide.fullname" . }}
+    mysql_cluster: {{ include "mysql-spotguide.clustername" . }}
 {{- end }}

--- a/.banzaicloud/charts/mysql-spotguide/values.yaml
+++ b/.banzaicloud/charts/mysql-spotguide/values.yaml
@@ -27,7 +27,7 @@ mysql:
   rootPassword:
   backup:
     enabled: false
-    schedule: "0 * * * * *" # every hour
+    schedule: "0 0 * * * *" # every hour
     limit: 8
     bucket: ""
     secret: ""

--- a/.banzaicloud/pipeline.yaml
+++ b/.banzaicloud/pipeline.yaml
@@ -63,12 +63,47 @@ pipeline:
       namespace: default
       merge: true
       spec:
+        - name: AWS_REGION
+          # value:
         - name: AWS_ACCESS_KEY_ID
           source: AWS_ACCESS_KEY_ID
         - name: AWS_SECRET_KEY
           source: AWS_SECRET_ACCESS_KEY
-        - name: AWS_REGION
+  {{{{- else if (and (.pipeline.deploy_mysql_cluster.deployment.values.mysql.backup.cloud) (eq .pipeline.deploy_mysql_cluster.deployment.values.mysql.backup.cloud "google")) }}}}
+  install_backup_secret:
+    when:
+      branch:
+        include: [master]
+    image: banzaicloud/ci-pipeline-client:0.10.1
+    action: InstallSecret
+    clusterSecret:
+      # sourceSecretName:
+      name: '{{ .CICD_REPO_NAME }}-backup'
+      namespace: default
+      merge: true
+      spec:
+        - name: GCS_LOCATION
           # value:
+        - name: GCS_SERVICE_ACCOUNT_JSON_KEY
+  {{{{- else if (and (.pipeline.deploy_mysql_cluster.deployment.values.mysql.backup.cloud) (eq .pipeline.deploy_mysql_cluster.deployment.values.mysql.backup.cloud "azure")) }}}}
+  install_backup_secret:
+    when:
+      branch:
+        include: [master]
+    image: banzaicloud/ci-pipeline-client:0.10.1
+    action: InstallSecret
+    clusterSecret:
+      # sourceSecretName:
+      name: '{{ .CICD_REPO_NAME }}-backup'
+      namespace: default
+      merge: true
+      spec:
+        - name: AZUREBLOB_LOCATION
+          # value:
+        - name: AZUREBLOB_KEY
+          source: accessKey
+        - name: AZUREBLOB_ACCOUNT
+          source: storageAccount
   {{{{- end }}}}
 {{{{- end }}}}
 
@@ -101,6 +136,7 @@ pipeline:
       reuseValues: true
       namespace: pipeline-system
       values:
+        helperImage: 'banzaicloud/mysql-helper:0.1.15'
         replicaCount: 1
         rbac:
           create: true

--- a/.banzaicloud/pipeline.yaml
+++ b/.banzaicloud/pipeline.yaml
@@ -107,6 +107,7 @@ pipeline:
   {{{{- end }}}}
 {{{{- end }}}}
 
+{{{{- if .pipeline.deploy_mysql_cluster.deployment.values.phpmyadmin.enabled }}}}
   install_phpmyadmin_control_secret:
     when:
       branch:
@@ -123,6 +124,7 @@ pipeline:
         source: username
       - name: password
         source: password
+{{{{- end }}}}
 
   deploy_mysql_operator:
     when:

--- a/.banzaicloud/spotguide.yaml
+++ b/.banzaicloud/spotguide.yaml
@@ -215,7 +215,7 @@ questions:
       - amazon
       - google
       - azure
-  description: In this version, only Amazon S3 and Google Storage buckets are supported
+  description: In this version, only Amazon S3, Google Storage and Azure Blob Storage are supported
   order: 15
   showIf:
     properties:

--- a/.banzaicloud/spotguide.yaml
+++ b/.banzaicloud/spotguide.yaml
@@ -200,10 +200,9 @@ questions:
 
 - type: pipeline
   dataType: boolean
-  label: Enable (coming soon...)
+  label: Enable
   key: enable_backups
   group: Mysql Server Backups
-  disabled: true
   default: false
   order: 14
   targets:
@@ -211,11 +210,12 @@ questions:
 
 - type: bucket
   group: Mysql Server Backups
-  hidden: true
   filter:
     cloud:
       - amazon
-  description: In this version, only AWS S3 buckets are supported
+      - google
+      - azure
+  description: In this version, only Amazon S3 and Google Storage buckets are supported
   order: 15
   showIf:
     properties:
@@ -224,17 +224,16 @@ questions:
   targets:
     - name: deploy_mysql_cluster.deployment.values.mysql.backup.bucket
     - cloud: deploy_mysql_cluster.deployment.values.mysql.backup.cloud
-    - location: install_backup_secret.clusterSecret.spec[2].value
+    - location: install_backup_secret.clusterSecret.spec[0].value
     - location: deploy_mysql_cluster.deployment.values.mysql.backup.location
     - secret.name: install_backup_secret.clusterSecret.sourceSecretName
 
 - type: pipeline
   dataType: string
   group: Mysql Server Backups
-  hidden: true
-  default: 0 * * * * *
+  default: 0 0 * * * *
   label: schedule
-  placeholder: CRON expression
+  placeholder: cron expression
   pattern: ^(((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1-5]{1}){1}([0-9]{1}){1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([0-9]{1}){1}|(([1]{1}){1}([0-9]{1}){1}){1}|([2]{1}){1}([0-3]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))) ((([\*]{1}){1})|((\*\/){0,1}(([1-9]{1}){1}|(([1-2]{1}){1}([0-9]{1}){1}){1}|([3]{1}){1}([0-1]{1}){1}))|(jan|feb|mar|apr|may|jun|jul|aug|sep|okt|nov|dec)) ((([\*]{1}){1})|((\*\/){0,1}(([0-7]{1}){1}))|(sun|mon|tue|wed|thu|fri|sat)))$
   order: 16
   targets:


### PR DESCRIPTION
added azure support to the [original](https://github.com/presslabs/mysql-operator/blob/0.1.x/hack/docker/mysql-helper/docker-entrypoint.sh) `docker-entrypoint.sh`:

```sh
#!/bin/sh
set -e

echo "Create rclone.conf file."
cat <<EOF > /etc/rclone.conf
[s3]
type = s3
env_auth = false
provider = ${S3_PROVIDER:-"AWS"}
access_key_id = ${AWS_ACCESS_KEY_ID}
secret_access_key = ${AWS_SECRET_KEY}
region = ${AWS_REGION:-"us-east-1"}
endpoint = ${S3_ENDPOINT}
acl = ${AWS_ACL}
storage_class = ${AWS_STORAGE_CLASS}

[gs]
type = google cloud storage
project_number = ${GCS_PROJECT_ID}
service_account_file = /tmp/google-credentials.json
object_acl = ${GCS_OBJECT_ACL}
bucket_acl = ${GCS_BUCKET_ACL}
location =  ${GCS_LOCATION}
storage_class = ${GCS_STORAGE_CLASS:-"MULTI_REGIONAL"}

[azure]
type = azureblob
account = ${AZUREBLOB_ACCOUNT}
key = ${AZUREBLOB_KEY}

[http]
type = http
url = ${HTTP_URL}

EOF

echo "Create google-credentials.json file."
cat <<EOF > /tmp/google-credentials.json
${GCS_SERVICE_ACCOUNT_JSON_KEY}
EOF

VERBOSE="-v 3"
#VERBOSE="-v 3"

# exec command
case "$1" in
    files-config)
        shift 1
        mysql-helper  $VERBOSE init-configs "$@"
        ;;
    clone)
        shift 1
        mysql-helper $VERBOSE clone "$@"
        ;;
    config-and-serve)
        shift 1
        mysql-helper $VERBOSE run "$@"
        ;;
    take-backup-to)
        shift 1
        mysql-helper $VERBOSE take-backup-to "$@"
        ;;
    schedule-backup)
        shift 1
        mysql-helper $VERBOSE schedule-backup "$@"
        ;;
    *)
        echo "Usage: $0 {files-config|clone|config-and-serve}"
        echo "Now runs your command."
        echo "$@"

        exec "$@"
esac

```